### PR TITLE
[HZC-3804] Add dns resolver for m1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,13 @@
         <dependency>
             <groupId>io.projectreactor.netty</groupId>
             <artifactId>reactor-netty-http</artifactId>
-            <version>1.0.24</version>
+            <version>1.0.25</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns-native-macos</artifactId>
+            <version>4.1.85.Final</version>
+            <classifier>osx-aarch_64</classifier>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION
Only solution for now is adding m1 dns resolver dependency. 
https://github.com/netty/netty/issues/11020#issuecomment-1014979901