### PR TITLE
DOCS-568 Product Renaming

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -4,7 +4,7 @@
 
 image:https://maven-badges.herokuapp.com/maven-central/com.hazelcast.cloud/hazelcast-cloud-maven-plugin/badge.svg[link="https://maven-badges.herokuapp.com/maven-central/com.hazelcast.cloud/hazelcast-cloud-maven-plugin"]
 
-The Hazelcast Viridian Maven Plugin is a Java development tool for testing and deploying cluster-side modules on Serverless clusters.
+The Viridian Cloud Maven Plugin is a Java development tool for testing and deploying cluster-side modules on Viridian Cloud Standard clusters.
 
 == Before you Begin
 
@@ -43,13 +43,13 @@ Make sure that you have the following:
 | clusterName
 | Cluster name
 
-Find your cluster name in the link:{page-cloud-console}[Hazelcast Viridian console] by clicking *Connect Client*.
+Find your cluster name in the link:{page-cloud-console}[Viridian Cloud console] by clicking *Connect Client*.
 | pr-a1b2c3d4
 
 | apiKey
 | API key
 
-Generate an API key and secret in the link:{page-cloud-console}/settings/developer[Hazelcast Viridian console].
+Generate an API key and secret in the link:{page-cloud-console}/settings/developer[Viridian Cloud console].
 a|N/A
 
 | apiSecret

--- a/docs/modules/ROOT/pages/maven-plugin-hazelcast.adoc
+++ b/docs/modules/ROOT/pages/maven-plugin-hazelcast.adoc
@@ -1,11 +1,10 @@
 = Hazelcast {hazelcast-cloud} Maven Plugin
 :description: This Maven plugin is a Java development tool for testing and deploying xref:cluster-side-modules.adoc[cluster-side modules].
 :page-plugin-version: 0.0.7
-:page-serverless: true
 
 {description}
 
-NOTE: This plugin is for {hazelcast-cloud} Serverless clusters only.
+NOTE: This plugin is for {hazelcast-cloud} Standard clusters only.
 
 == Before you Begin
 
@@ -44,13 +43,13 @@ Make sure that you have the following:
 | clusterName
 | Cluster name
 
-Find your cluster name in the link:{page-cloud-console}[Hazelcast {hazelcast-cloud} console] by clicking *Connect Client*.
+Find your cluster name in the link:{page-cloud-console}[{hazelcast-cloud} console] by clicking *Connect Client*.
 | pr-1234
 
 | apiKey
 | API key
 
-Generate an API key and secret in the link:{page-cloud-console}settings/developer[Hazelcast {hazelcast-cloud} console].
+Generate an API key and secret in the link:{page-cloud-console}settings/developer[{hazelcast-cloud} console].
 a|N/A
 
 | apiSecret


### PR DESCRIPTION
Renaming to Viridian Cloud +

Viridian Cloud Standard instead of Viridian Cloud Serverless
Viridian Cloud Dedicated instead of Hazelcast Viridian Dedicated