### PR TITLE
HZC-7235: change-cloud-url

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -24,7 +24,7 @@ Make sure that you have the following:
             <artifactId>hazelcast-cloud-maven-plugin</artifactId>
             <version>{page-plugin-version}</version>
             <configuration>
-                <apiBaseUrl>https://api.viridian.hazelcast.com</apiBaseUrl>
+                <apiBaseUrl>https://api.cloud.hazelcast.com</apiBaseUrl>
                 <clusterId>$\{clusterId}</clusterId>
                 <apiKey>$\{apiKey}</apiKey>
                 <apiSecret>$\{apiSecret}</apiSecret>

--- a/src/main/java/com/hazelcast/cloud/maven/DeployHandler.java
+++ b/src/main/java/com/hazelcast/cloud/maven/DeployHandler.java
@@ -24,7 +24,7 @@ import static org.codehaus.plexus.util.StringUtils.isEmpty;
 @Setter
 public class DeployHandler extends AbstractMojo {
 
-    @Parameter(property = "apiBaseUrl", defaultValue = "https://api.viridian.hazelcast.com")
+    @Parameter(property = "apiBaseUrl", defaultValue = "https://api.cloud.hazelcast.com")
     private String apiBaseUrl;
 
     @Parameter(property = "clusterId", required = true)

--- a/src/test/java/com/hazelcast/cloud/maven/DeployHandlerTest.java
+++ b/src/test/java/com/hazelcast/cloud/maven/DeployHandlerTest.java
@@ -49,9 +49,9 @@ public class DeployHandlerTest {
     private static Stream<Arguments> should_fail_given_invalid_params() {
         return Stream.of(
             Arguments.of(null, "a1b2c3d4", "api-key", "api-secret"),
-            Arguments.of("https://api.viridian.hazelcast.com", null, "api-key", "api-key"),
-            Arguments.of("https://api.viridian.hazelcast.com", "a1b2c3d4", null, "api-secret"),
-            Arguments.of("https://api.viridian.hazelcast.com", "a1b2c3d4", "api-key", null)
+            Arguments.of("https://api.cloud.hazelcast.com", null, "api-key", "api-key"),
+            Arguments.of("https://api.cloud.hazelcast.com", "a1b2c3d4", null, "api-secret"),
+            Arguments.of("https://api.cloud.hazelcast.com", "a1b2c3d4", "api-key", null)
         );
     }
 

--- a/src/test/java/com/hazelcast/cloud/maven/LogHandlerTest.java
+++ b/src/test/java/com/hazelcast/cloud/maven/LogHandlerTest.java
@@ -49,9 +49,9 @@ public class LogHandlerTest {
     private static Stream<Arguments> should_fail_given_invalid_params() {
         return Stream.of(
             Arguments.of(null, "a1b2c3d4", "api-key", "api-secret"),
-            Arguments.of("https://api.viridian.hazelcast.com", null, "api-key", "api-key"),
-            Arguments.of("https://api.viridian.hazelcast.com", "a1b2c3d4", null, "api-secret"),
-            Arguments.of("https://api.viridian.hazelcast.com", "a1b2c3d4", "api-key", null)
+            Arguments.of("https://api.cloud.hazelcast.com", null, "api-key", "api-key"),
+            Arguments.of("https://api.cloud.hazelcast.com", "a1b2c3d4", null, "api-secret"),
+            Arguments.of("https://api.cloud.hazelcast.com", "a1b2c3d4", "api-key", null)
         );
     }
 


### PR DESCRIPTION
chore: update cloud url to api.cloud.hazelcast.com to part of deprecation of using viridian